### PR TITLE
Fix learn mode skipping and progress

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ public
 
 .gitignore
 .eslintignore
+apps/next/next.config.mjs


### PR DESCRIPTION
## Summary
- handle no-repeat for missed familiar terms
- adjust progress counting when dropping to `-1`
- fix round end condition to use question index instead of progress
- skip repeating incorrect write questions

## Testing
- `bun run format`
- `bun run build` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_68515b798828832eb2d932d3c3116f79