### PR TITLE
Fix repeated mutation calls in retype answer state

### DIFF
--- a/apps/next/src/modules/learn/cards/write/retype-answer-state.tsx
+++ b/apps/next/src/modules/learn/cards/write/retype-answer-state.tsx
@@ -49,7 +49,7 @@ export const RetypeAnswerState: React.FC<RetypeAnswerStateProps> = ({
 
   const put = api.studiableTerms.put.useMutation();
 
-  const handleAcknowledgeIncorrect = React.useCallback(() => {
+  React.useEffect(() => {
     const active = roundTimeline[roundCounter]!;
     if (active.type == "write") {
       void (async () =>
@@ -62,11 +62,9 @@ export const RetypeAnswerState: React.FC<RetypeAnswerStateProps> = ({
           incorrectCount: active.term.incorrectCount + 1,
         }))();
     }
-  }, [container.id, put, roundCounter, roundTimeline]);
-
-  React.useEffect(() => {
-    handleAcknowledgeIncorrect();
-  }, [handleAcknowledgeIncorrect]);
+    // We only want to mark the term incorrect once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const inputBg = useColorModeValue("gray.100", "gray.800");
   const placeholderColor = useColorModeValue("gray.600", "gray.200");


### PR DESCRIPTION
## Summary
- fix repeated studiableTerms.put calls while retyping incorrect answers

## Testing
- `bun test`
- `bun run lint` *(fails: FATAL ERROR: Reached heap limit Allocation failed)*

------
https://chatgpt.com/codex/tasks/task_b_6855242527dc832e8155d270e3049fdd