### PR TITLE
Add spaced repetition mode to prisma schema

### DIFF
--- a/packages/prisma/migrations/20250622141630_spaced_repetition/migration.sql
+++ b/packages/prisma/migrations/20250622141630_spaced_repetition/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE `Container` ADD COLUMN `nextReviewAt` DATETIME(3) NULL,
+    ADD COLUMN `spacedDailyLimit` INTEGER NOT NULL DEFAULT 10,
+    ADD COLUMN `spacedRound` INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE `StudiableTerm` DROP PRIMARY KEY,
+    MODIFY `mode` ENUM('Flashcards', 'Learn', 'SpacedRepetition') NOT NULL DEFAULT 'Learn',
+    ADD PRIMARY KEY (`userId`, `containerId`, `termId`, `mode`);
+

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -648,6 +648,7 @@ enum EntityType {
 enum StudiableMode {
   Flashcards
   Learn
+  SpacedRepetition
 }
 
 enum LearnMode {
@@ -702,6 +703,9 @@ model Container {
   cardsAnswerWith      LimitedStudySetAnswerMode @default(Definition)
   matchStudyStarred    Boolean                   @default(false)
   requireRetyping      Boolean                   @default(false)
+  spacedRound          Int                       @default(0)
+  nextReviewAt         DateTime?
+  spacedDailyLimit     Int                       @default(10)
 
   starredTerms   StarredTerm[]
   studiableTerms StudiableTerm[]


### PR DESCRIPTION
## Summary
- extend `StudiableMode` with `SpacedRepetition`
- record spaced-repetition related fields on `Container`
- create a migration and regenerate Prisma client

## Testing
- `bunx prisma format`
- `bunx prisma generate`
- `bunx prisma migrate diff --from-schema-datamodel /tmp/old_schema.prisma --to-schema-datamodel /tmp/new_schema.prisma --script`
- `npm run lint` *(fails: Reached heap limit)*

------
https://chatgpt.com/codex/tasks/task_b_68580f607460832ebb429d5015bfe3ab