### PR TITLE
Add learn question type settings

### DIFF
--- a/apps/next/src/modules/create-learn-data.tsx
+++ b/apps/next/src/modules/create-learn-data.tsx
@@ -57,6 +57,7 @@ export const CreateLearnData: React.FC<React.PropsWithChildren> = ({
       .initialize(
         container.learnMode,
         container.answerWith,
+        container.learnQuestionTypes,
         learnTerms as StudiableTermWithDistractors[],
         terms as TermWithDistractors[],
         container.learnRound,

--- a/apps/next/src/modules/hydrate-set-data.tsx
+++ b/apps/next/src/modules/hydrate-set-data.tsx
@@ -174,6 +174,10 @@ const ContextLayer: React.FC<React.PropsWithChildren<ContextLayerProps>> = ({
     cardsAnswerWith: data.container.cardsAnswerWith,
     matchStudyStarred: data.container.matchStudyStarred,
     requireRetyping: data.container.requireRetyping,
+    learnQuestionTypes: data.container.learnQuestionTypes as (
+      | "choice"
+      | "write"
+    )[],
   });
 
   const storeRef = React.useRef<ContainerStore>();

--- a/apps/next/src/modules/learn/learn-settings-modal.tsx
+++ b/apps/next/src/modules/learn/learn-settings-modal.tsx
@@ -12,6 +12,7 @@ import { useSetPropertiesStore } from "../../stores/use-set-properties-store";
 import { AnswerModeSection } from "./settings/answer-mode-section";
 import { ExtendedFeedbackSection } from "./settings/extended-feedback-bank-section";
 import { MultipleAnswerModeSection } from "./settings/multiple-answer-mode-section";
+import { QuestionTypeSection } from "./settings/question-type-section";
 import { RequireRetypingSection } from "./settings/require-retyping-section";
 import { ResetProgressSection } from "./settings/reset-progress-section";
 import { ShuffleLearnSection } from "./settings/shuffle-learn-section";
@@ -49,6 +50,7 @@ export const LearnSettingsModal: React.FC<LearnSettingsModal> = ({
   const studyStarred = useContainerContext((s) => s.studyStarred);
   const answerWith = useContainerContext((s) => s.answerWith);
   const requireRetyping = useContainerContext((s) => s.requireRetyping);
+  const learnQuestionTypes = useContainerContext((s) => s.learnQuestionTypes);
   const multipleAnswerMode = useContainerContext((s) => s.multipleAnswerMode);
   const setIsDirty = useSetPropertiesStore((s) => s.setIsDirty);
 
@@ -63,7 +65,8 @@ export const LearnSettingsModal: React.FC<LearnSettingsModal> = ({
             container.shuffleLearn !== shuffleLearn ||
             container.answerWith !== answerWith ||
             container.studyStarred !== studyStarred ||
-            container.requireRetyping !== requireRetyping;
+            container.requireRetyping !== requireRetyping ||
+            container.learnQuestionTypes.join() !== learnQuestionTypes.join();
 
           setIsDirty(isDirty);
           onClose();
@@ -78,6 +81,8 @@ export const LearnSettingsModal: React.FC<LearnSettingsModal> = ({
             <StudyStarredSection />
             <Modal.Divider />
             <ShuffleLearnSection />
+            <Modal.Divider />
+            <QuestionTypeSection />
             <Modal.Divider />
             <AnswerModeSection />
             {multipleAnswerMode !== "Unknown" && (

--- a/apps/next/src/modules/learn/settings/question-type-section.tsx
+++ b/apps/next/src/modules/learn/settings/question-type-section.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+
+import { api } from "@quenti/trpc";
+
+import {
+  Box,
+  Button,
+  GridItem,
+  HStack,
+  SimpleGrid,
+  Text,
+  useColorModeValue,
+} from "@chakra-ui/react";
+
+import { IconLayoutGrid, IconPencil } from "@tabler/icons-react";
+
+import { useSet } from "../../hooks/use-set";
+import { useContainerContext } from "../../stores/use-container-store";
+
+const typeConfig = {
+  choice: {
+    label: "Multiple choice",
+    Icon: IconLayoutGrid,
+  },
+  write: {
+    label: "Written",
+    Icon: IconPencil,
+  },
+} as const;
+
+export const QuestionTypeSection: React.FC = () => {
+  const { id } = useSet();
+  const questionTypes = useContainerContext((s) => s.learnQuestionTypes);
+  const setQuestionTypes = useContainerContext((s) => s.setLearnQuestionTypes);
+  const apiMutation = api.container.setLearnQuestionTypes.useMutation();
+
+  const toggle = (type: "choice" | "write") => {
+    const next = questionTypes.includes(type)
+      ? questionTypes.filter((t) => t !== type)
+      : [...questionTypes, type];
+    setQuestionTypes(next);
+    apiMutation.mutate({ entityId: id, learnQuestionTypes: next });
+  };
+
+  const selectedBorder = useColorModeValue("blue.600", "blue.200");
+  const defaultBorder = useColorModeValue("gray.200", "gray.600");
+
+  return (
+    <SimpleGrid columns={{ base: 1, sm: 2 }} spacing="3">
+      {(Object.keys(typeConfig) as ("choice" | "write")[]).map((type) => {
+        const { label, Icon } = typeConfig[type];
+        const checked = questionTypes.includes(type);
+        return (
+          <GridItem key={type}>
+            <Button
+              w="full"
+              variant="outline"
+              rounded="xl"
+              bg="transparent"
+              borderWidth="2px"
+              borderColor={checked ? selectedBorder : defaultBorder}
+              py="6"
+              px="4"
+              colorScheme="gray"
+              onClick={() => toggle(type)}
+            >
+              <HStack w="full">
+                <Box
+                  transition="color 0.15s ease-in-out"
+                  color={checked ? selectedBorder : "gray.400"}
+                  _dark={{ color: checked ? selectedBorder : "gray.500" }}
+                >
+                  <Icon size={20} />
+                </Box>
+                <Text fontWeight={600}>{label}</Text>
+              </HStack>
+            </Button>
+          </GridItem>
+        );
+      })}
+    </SimpleGrid>
+  );
+};

--- a/apps/next/src/stores/use-container-store.ts
+++ b/apps/next/src/stores/use-container-store.ts
@@ -22,6 +22,7 @@ export interface ContainerStoreProps {
   matchStudyStarred: boolean;
   starredTerms: string[];
   requireRetyping: boolean;
+  learnQuestionTypes: ("choice" | "write")[];
 }
 
 interface ContainerState extends ContainerStoreProps {
@@ -37,6 +38,7 @@ interface ContainerState extends ContainerStoreProps {
   setCardsAnswerWith: (cardsAnswerWith: LimitedStudySetAnswerMode) => void;
   setMatchStudyStarred: (matchStudyStarred: boolean) => void;
   setRequireRetyping: (requireRetyping: boolean) => void;
+  setLearnQuestionTypes: (learnQuestionTypes: ("choice" | "write")[]) => void;
   starTerm: (termId: string) => void;
   unstarTerm: (termId: string) => void;
 }
@@ -60,6 +62,7 @@ export const createContainerStore = (
     matchStudyStarred: false,
     starredTerms: [],
     requireRetyping: false,
+    learnQuestionTypes: ["choice", "write"],
   };
 
   return createStore<ContainerState>()(
@@ -97,6 +100,8 @@ export const createContainerStore = (
         set({ matchStudyStarred }),
       setRequireRetyping: (requireRetyping: boolean) =>
         set({ requireRetyping }),
+      setLearnQuestionTypes: (learnQuestionTypes: ("choice" | "write")[]) =>
+        set({ learnQuestionTypes }),
       starTerm: (termId: string) => {
         set((state) => {
           return {

--- a/apps/next/src/stores/use-learn-store.ts
+++ b/apps/next/src/stores/use-learn-store.ts
@@ -29,6 +29,7 @@ export interface LearnStoreProps {
   roundTimeline: Question[];
   specialCharacters: string[];
   feedbackBank: { correct: string[]; incorrect: string[] };
+  questionTypes: ("choice" | "write")[];
   answered?: string;
   status?: "correct" | "incorrect" | "unknownPartial";
   roundSummary?: RoundSummary;
@@ -44,6 +45,7 @@ interface LearnState extends LearnStoreProps {
   initialize: (
     mode: LearnMode,
     answerMode: StudySetAnswerMode,
+    questionTypes: ("choice" | "write")[],
     studiableTerms: StudiableTermWithDistractors[],
     allTerms: TermWithDistractors[],
     round: number,
@@ -79,6 +81,7 @@ export const createLearnStore = (initProps?: Partial<LearnStoreProps>) => {
     roundTimeline: [],
     specialCharacters: [],
     feedbackBank: { correct: CORRECT, incorrect: INCORRECT },
+    questionTypes: ["choice", "write"],
     completed: false,
     hintsUsed: new Map<string, boolean>(),
     isRetyping: false,
@@ -89,7 +92,14 @@ export const createLearnStore = (initProps?: Partial<LearnStoreProps>) => {
     subscribeWithSelector((set) => ({
       ...DEFAULT_PROPS,
       ...initProps,
-      initialize: (mode, answerMode, studiableTerms, allTerms, round) => {
+      initialize: (
+        mode,
+        answerMode,
+        questionTypes,
+        studiableTerms,
+        allTerms,
+        round,
+      ) => {
         const words =
           answerMode != "Both"
             ? studiableTerms.map((x) => word(answerMode, x, "answer"))
@@ -112,6 +122,7 @@ export const createLearnStore = (initProps?: Partial<LearnStoreProps>) => {
         set({
           mode,
           answerMode,
+          questionTypes,
           studiableTerms,
           allTerms,
           numTerms: studiableTerms.length,
@@ -356,7 +367,15 @@ export const createLearnStore = (initProps?: Partial<LearnStoreProps>) => {
           });
 
           const roundTimeline: Question[] = termsThisRound.map((term) => {
-            const choice = term.correctness < 1;
+            let choice: boolean;
+            if (
+              state.questionTypes.includes("choice") &&
+              state.questionTypes.includes("write")
+            ) {
+              choice = term.correctness < 1;
+            } else {
+              choice = state.questionTypes.includes("choice");
+            }
             const answerMode: StudySetAnswerMode =
               state.answerMode != "Both"
                 ? state.answerMode

--- a/packages/prisma/migrations/20250704004711_learn_question_types/migration.sql
+++ b/packages/prisma/migrations/20250704004711_learn_question_types/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Container` ADD COLUMN `learnQuestionTypes` VARCHAR(191) NOT NULL DEFAULT '["choice","write"]';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -692,6 +692,7 @@ model Container {
   learnRound           Int                       @default(0)
   learnMode            LearnMode                 @default(Learn)
   shuffleLearn         Boolean                   @default(false)
+  learnQuestionTypes   String                    @default("[\"choice\",\"write\"]")
   studyStarred         Boolean                   @default(false)
   answerWith           StudySetAnswerMode        @default(Word)
   multipleAnswerMode   MultipleAnswerMode        @default(Unknown)

--- a/packages/trpc/server/routers/container/_router.ts
+++ b/packages/trpc/server/routers/container/_router.ts
@@ -16,6 +16,7 @@ import { ZSetCardsAnswerWithSchema } from "./set-cards-answer-with.schema";
 import { ZSetCardsStudyStarredSchema } from "./set-cards-study-starred.schema";
 import { ZSetEnableCardsSortingSchema } from "./set-enable-cards-sorting.schema";
 import { ZSetExtendedFeedbackBankSchema } from "./set-extended-feedback-bank.schema";
+import { ZSetLearnQuestionTypesSchema } from "./set-learn-question-types.schema";
 import { ZSetMatchStudyStarredSchema } from "./set-match-study-starred.schema";
 import { ZSetMultipleAnswerModeSchema } from "./set-multiple-answer-mode.schema";
 import { ZSetRequireRetypingSchema } from "./set-require-retyping.schema";
@@ -38,6 +39,7 @@ type ContainerRouterHandlerCache = {
     ["set-shuffle-learn"]?: typeof import("./set-shuffle-learn.handler").setShuffleLearnHandler;
     ["set-extended-feedback-bank"]?: typeof import("./set-extended-feedback-bank.handler").setExtendedFeedbackBankHandler;
     ["set-require-retyping"]?: typeof import("./set-require-retyping.handler").default;
+    ["set-learn-question-types"]?: typeof import("./set-learn-question-types.handler").setLearnQuestionTypesHandler;
     ["star-term"]?: typeof import("./star-term.handler").starTermHandler;
     ["unstar-term"]?: typeof import("./unstar-term.handler").unstarTermHandler;
     ["complete-learn-round"]?: typeof import("./complete-learn-round.handler").completeLearnRoundHandler;
@@ -139,6 +141,15 @@ export const containerRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       await loadHandler(HANDLER_CACHE, "set-require-retyping");
       return HANDLER_CACHE.handlers["set-require-retyping"]!({
+        ctx,
+        input,
+      });
+    }),
+  setLearnQuestionTypes: protectedProcedure
+    .input(ZSetLearnQuestionTypesSchema)
+    .mutation(async ({ ctx, input }) => {
+      await loadHandler(HANDLER_CACHE, "set-learn-question-types");
+      return HANDLER_CACHE.handlers["set-learn-question-types"]!({
         ctx,
         input,
       });

--- a/packages/trpc/server/routers/container/set-learn-question-types.handler.ts
+++ b/packages/trpc/server/routers/container/set-learn-question-types.handler.ts
@@ -1,0 +1,27 @@
+import type { NonNullableUserContext } from "../../lib/types";
+import type { TSetLearnQuestionTypesSchema } from "./set-learn-question-types.schema";
+
+type SetLearnQuestionTypesOptions = {
+  ctx: NonNullableUserContext;
+  input: TSetLearnQuestionTypesSchema;
+};
+
+export const setLearnQuestionTypesHandler = async ({
+  ctx,
+  input,
+}: SetLearnQuestionTypesOptions) => {
+  await ctx.prisma.container.update({
+    where: {
+      userId_entityId_type: {
+        userId: ctx.session.user.id,
+        entityId: input.entityId,
+        type: "StudySet",
+      },
+    },
+    data: {
+      learnQuestionTypes: JSON.stringify(input.learnQuestionTypes),
+    },
+  });
+};
+
+export default setLearnQuestionTypesHandler;

--- a/packages/trpc/server/routers/container/set-learn-question-types.schema.ts
+++ b/packages/trpc/server/routers/container/set-learn-question-types.schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const ZSetLearnQuestionTypesSchema = z.object({
+  entityId: z.string(),
+  learnQuestionTypes: z.array(z.enum(["choice", "write"])),
+});
+
+export type TSetLearnQuestionTypesSchema = z.infer<
+  typeof ZSetLearnQuestionTypesSchema
+>;

--- a/packages/trpc/server/routers/study-sets/by-id.handler.ts
+++ b/packages/trpc/server/routers/study-sets/by-id.handler.ts
@@ -196,6 +196,7 @@ export const byIdHandler = async ({ ctx, input }: ByIdOptions) => {
     },
     container: {
       ...container,
+      learnQuestionTypes: JSON.parse(container.learnQuestionTypes),
       starredTerms: container.starredTerms.map((x: StarredTerm) => x.termId),
       studiableTerms: container.studiableTerms.map((x: StudiableTerm) => ({
         id: x.termId,


### PR DESCRIPTION
## Summary
- support learn question types in container store and prisma
- persist learn question types via TRPC
- parse learn question types in study set data
- allow toggling question types in Learn settings

## Testing
- `npx prettier --write ...` *(ran successfully)*
- `npm run lint` *(failed: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_b_6867222a3b8c832e913e7b9681fd3d67