### PR TITLE
Fix learn mode progress bar

### DIFF
--- a/apps/next/src/stores/use-learn-store.ts
+++ b/apps/next/src/stores/use-learn-store.ts
@@ -207,9 +207,6 @@ export const createLearnStore = (initProps?: Partial<LearnStoreProps>) => {
             });
           }
 
-          if (active.term.correctness !== -1 && active.term.correctness !== 1) {
-            state.roundProgress++;
-          }
           if (!shouldRepeat) state.prevTermWasIncorrect = false;
 
           state.endQuestionCallback();
@@ -280,11 +277,8 @@ export const createLearnStore = (initProps?: Partial<LearnStoreProps>) => {
 
           const roundCounter = state.roundCounter + 1;
           const active = state.roundTimeline[state.roundCounter]!;
-          const progressIncrement =
-            active.term.correctness !== -1 && active.term.correctness !== 1
-              ? 1
-              : 0;
-          const roundProgress = state.roundProgress + progressIncrement;
+          const shouldRepeat = active.term.correctness === -2;
+          const roundProgress = state.roundProgress + (shouldRepeat ? 0 : 1);
 
           return {
             roundCounter,
@@ -343,9 +337,6 @@ export const createLearnStore = (initProps?: Partial<LearnStoreProps>) => {
           active.term.correctness = newCorrectness;
           active.term.incorrectCount++;
 
-          if (active.term.correctness !== -1 && active.term.correctness !== 1) {
-            state.roundProgress++;
-          }
           if (!shouldRepeat) state.prevTermWasIncorrect = false;
 
           state.endQuestionCallback();


### PR DESCRIPTION
This pull request refactors how the learning round progress is incremented in the `use-learn-store` logic. The updates clarify the conditions under which `roundProgress` should be increased, focusing on whether a term should be repeated rather than relying on correctness codes.

**Progress increment logic improvements:**

* Refactored the condition for incrementing `roundProgress` to depend on the `shouldRepeat` flag instead of checking for specific correctness values, making the logic clearer and less error-prone. (`apps/next/src/stores/use-learn-store.ts`)

* Removed duplicate and outdated checks for correctness values when incrementing `roundProgress` in multiple places, consolidating the logic and reducing code redundancy. (`apps/next/src/stores/use-learn-store.ts`) [[1]](diffhunk://#diff-513897749c059cee83911b222cf28a2033f27bfa88c9352f1ca56fcabd4581f7L210-L212) [[2]](diffhunk://#diff-513897749c059cee83911b222cf28a2033f27bfa88c9352f1ca56fcabd4581f7L346-L348)